### PR TITLE
fix(subset): recompute diff records against newly packed parent

### DIFF
--- a/src/arlmet/subset.py
+++ b/src/arlmet/subset.py
@@ -7,13 +7,10 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import numpy as np
-
 from arlmet.file import File
 from arlmet.grid import Grid, GridWindow
 from arlmet.header import Header, record_length_from_grid, split_grid_component
 from arlmet.index import IndexRecord, LvlInfo, VarInfo, _derive_index_forecast
-from arlmet.packing import unpack
 from arlmet.record import DataRecord
 from arlmet.vertical import VerticalAxis
 
@@ -252,45 +249,15 @@ def extract_subset(
                     forecast=src_recordset.forecast,
                 )
                 for record in selected_records:
-                    if record.diff is None:
-                        data = record.read(window=window)
-                        dst_recordset.create_datarecord(
-                            variable=record.variable,
-                            level=level_map[record.level],
-                            forecast=record.forecast,
-                            data=data,
-                        )
-                        continue
-
-                    parent_data = np.asarray(
-                        unpack(
-                            packed=record.bytes[Header.N_BYTES :],
-                            nx=source.grid.nx,
-                            ny=source.grid.ny,
-                            precision=record.header.precision,
-                            exponent=record.header.exponent,
-                            initial_value=record.header.initial_value,
-                            window=window,
-                            driver=np,
-                        ),
-                        dtype=np.float32,
-                    )
-                    diff_data = np.asarray(
-                        record.diff.read(window=window), dtype=np.float32
-                    )
-                    destination.register_diff_binding(
-                        diff_name=record.diff.variable,
-                        parent_name=record.variable,
-                    )
-                    dst_parent = dst_recordset.create_datarecord(
+                    # record.read() returns the full-precision value
+                    # (parent + diff when a diff is attached); the diff branch
+                    # below relies on this so that create_datarecord(diff=...)
+                    # can recompute the diff against the newly packed parent.
+                    data = record.read(window=window)
+                    dst_recordset.create_datarecord(
                         variable=record.variable,
                         level=level_map[record.level],
                         forecast=record.forecast,
-                        data=parent_data,
+                        data=data,
+                        diff=record.diff.variable if record.diff is not None else None,
                     )
-                    dst_diff = dst_parent._create_diff(
-                        position=-1,
-                        variable=record.diff.variable,
-                        forecast=record.diff.forecast,
-                    )
-                    dst_diff[:] = diff_data

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -174,6 +174,66 @@ def test_extract_subset_preserves_diff_records(tmp_path):
         )
 
 
+def test_extract_subset_recomputes_diff_records_no_systematic_bias(tmp_path):
+    """
+    Cropping a diff-encoded record must not introduce a systematic value bias.
+
+    Regression test for the bug where ``extract_subset`` copied diff records
+    verbatim while repacking the parent with a new exponent + initial_value,
+    leaving the diff aligned with the old quantization grid. The result was a
+    small but non-zero-mean offset across the entire cropped grid that
+    compounded in downstream STILT trajectory integrations.
+
+    The fixture is engineered so the full grid's data range (driven by large
+    outside-window values) yields a parent exponent that differs from the
+    cropped subset's exponent — which is exactly the regime where the old
+    bug manifested. The diff record carries the high-frequency content that
+    only round-trips correctly if recomputed against the newly packed parent.
+    """
+    source = tmp_path / "diff_source.arl"
+    destination = tmp_path / "diff_subset.arl"
+    grid = make_test_grid(nx=60, ny=60)
+    vertical_axis = VerticalAxis(flag=2, levels=[1000.0])
+    time0 = pd.Timestamp("2024-07-18 00:00")
+
+    rng = np.random.default_rng(42)
+    data = (100.0 + 50.0 * rng.standard_normal((grid.ny, grid.nx))).astype(np.float32)
+    # Cropped window is approximately cells [5..50, 5..50].  Put small,
+    # smoothly-varying values there so the cropped exponent is much smaller
+    # than the full-grid exponent set by the surrounding noise.
+    yy, xx = np.mgrid[5:50, 5:50].astype(np.float32)
+    data[5:50, 5:50] = 0.001 * (np.sin(xx) + np.cos(yy)) + 0.0001 * rng.standard_normal(
+        (45, 45)
+    ).astype(np.float32)
+
+    with File(
+        source, mode="w", source="TEST", grid=grid, vertical_axis=vertical_axis
+    ) as arl:
+        rs = arl.create_recordset(time0)
+        rs.create_datarecord("WWND", level=0, forecast=0, data=data, diff="DIFW")
+
+    bbox = (25.0, -5.0, 70.0, 40.0)
+    extract_subset(source, destination, bbox=bbox)
+
+    with File(source) as original, File(destination) as subset:
+        source_window = original.grid.window_from_bbox(bbox)
+        source_record = original[time0][(0, "WWND")]
+        subset_record = subset[time0][(0, "WWND")]
+
+        diff_grid = subset_record.read() - source_record.read(window=source_window)
+        mean_signed_bias = float(diff_grid.mean())
+        precision = subset_record.header.precision
+
+        # Random per-cell quantization noise averages to ~0; a systematic
+        # bias on the order of the precision quantum indicates the diff
+        # record was not recomputed against the newly packed parent.
+        assert abs(mean_signed_bias) < precision * 0.01, (
+            f"Systematic bias {mean_signed_bias:+.3e} exceeds 1% of the "
+            f"packing precision {precision:.3e}; diff record likely not "
+            f"recomputed after repacking the parent."
+        )
+
+
 def test_open_dataset_bbox_and_levels_reads_only_selected_subset(tmp_path):
     source = tmp_path / "source.arl"
     write_subset_source(source)


### PR DESCRIPTION
Closes #14

## Summary
`extract_subset` was copying diff records verbatim while repacking the parent with a new exponent + initial_value, leaving the diff aligned with the old quantization grid. Reconstructing `parent + diff` after the crop produced a small systematic offset across the cropped grid that compounded in downstream STILT trajectories.

Route the diff branch through `create_datarecord(diff=...)`, which already triggers `record._pack`'s auto-derive-on-pack machinery — the same unpack-after-pack-then-recompute pattern that `xtrct_grid.f` uses around lines 502–518.

## Test plan
- New regression test `test_extract_subset_recomputes_diff_records_no_systematic_bias` engineers a parent-exponent mismatch between full and cropped grids; it fails on the old code (~3% precision-quantum bias) and passes (<0.01%) on the fix.
- Full `tests/test_subset.py` suite passes.
- Verified empirically on a real HRRR file (`20210101_18-23_hrrr`): WWND systematic bias drops from 5–85× larger than `xtrct_grid` to at or below `xtrct_grid`'s level at every level checked.
