### PR TITLE
feat(concat): concatenate ARL files into longer files (concat, concat_by_time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to arl-met are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `concat(sources, destination, *, sort=True)`: concatenate multiple ARL files into one via a byte-level append. Inputs are first scanned to ensure they share a grid and vertical axis and do not repeat valid times, then joined in valid-time order (`sort=True`, the default) or in the order given. New public export `arlmet.concat`
+- `concat_by_time(directory, output_directory, freq="1D", *, pattern, time_range, template, sort)`: batch form of `concat` that groups a directory of ARL files into time-binned chunks — e.g. 6-hourly HRRR files into daily files. Each file is assigned to a bin by its first valid time, read from the index record rather than parsed from the filename. New public export `arlmet.concat_by_time`
+
 ## [0.1.0a4] - 2026-06-03
 
 ### Added

--- a/src/arlmet/__init__.py
+++ b/src/arlmet/__init__.py
@@ -7,6 +7,7 @@ packed meteorological data files used by HYSPLIT and other atmospheric transport
 
 import importlib.metadata
 
+from .concat import concat, concat_by_time
 from .file import File
 from .grid import Grid, Projection
 from .header import Header
@@ -46,4 +47,6 @@ __all__ = [
     "unpack",
     "extract_subset",
     "sample_points",
+    "concat",
+    "concat_by_time",
 ]

--- a/src/arlmet/concat.py
+++ b/src/arlmet/concat.py
@@ -1,41 +1,296 @@
-import glob
+"""
+Concatenate ARL meteorology files into a single ARL file.
+
+ARL files are flat streams of fixed-size records, so joining several files is a
+byte-level append — the same operation as ``cat a.arl b.arl > out.arl``. This is
+the standard way to combine short (e.g. 6-hourly) met files into longer (e.g.
+daily) files: HYSPLIT limits a simulation to at most 12 meteorological input
+files when a single grid is specified, so longer per-file coverage is the only
+way to span a long run. See the HYSPLIT user guide, "Compilation Limits":
+https://www.ready.noaa.gov/hysplitusersguide/S441.htm
+
+The original idea and the HRRR use case come from Derek Mallia's
+``concat_hrrr_daily.py`` script.
+"""
+
+from __future__ import annotations
+
 import os
-import subprocess
+import shutil
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
 
-# This script takes 6 hourly HRRR files and concatenates these
-# into daily chunks so avoid file limit issues within HYSPLIT,
-# which will not allow more than 12 met files to be included as
-# inputs.     DVM 6/18/2026
+import pandas as pd
 
-# What is our input and output directories?
-input_dir = "./hrrr"
-output_dir = "./HRRR_tmp"
+from arlmet.file import File
+from arlmet.index import IndexRecord
 
-# What months and year are we processing?
-year = "2024"
-months = [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
+__all__ = ["concat", "concat_by_time"]
 
-# Make the output directory if it does not exist
-os.makedirs(output_dir, exist_ok=True)
 
-# Loop through each month
-for month in months:
-    # Find all the unique days for the period of time we are looking at
-    days = sorted(
-        {
-            os.path.basename(f).split("_")[0]
-            for f in glob.glob(f"{input_dir}/{year}{month:02d}*_hrrr")
-        }
-    )
+def concat(
+    sources: Iterable[str | os.PathLike[str]],
+    destination: str | os.PathLike[str],
+    *,
+    sort: bool = True,
+) -> File:
+    """
+    Concatenate multiple ARL files into a single ARL file.
 
-    # Loop through each day, and then find the HRRR files for the
-    # corresponding day. Then concatenate the files together
-    for day in days:
-        files = sorted(glob.glob(f"{input_dir}/{day}_*_hrrr"))
-        if len(files) == 0:
+    Each input is appended to the output byte-for-byte, preserving every record
+    (including diff records and checksums) exactly. The inputs are first scanned
+    to ensure they share one grid and vertical axis and do not repeat valid
+    times, since a concatenated ARL file must be a single coherent record stream.
+
+    Parameters
+    ----------
+    sources : iterable of path-like
+        Input ARL files to join. Must contain at least one path. A bare string
+        or path is rejected — wrap a single file in a list.
+    destination : path-like
+        Output ARL file path. Overwrites any existing file. Must not be one of
+        ``sources``.
+    sort : bool, default True
+        Order the inputs by their earliest valid time before joining, so the
+        output is chronological regardless of input order. When False, inputs
+        are joined in the order given (like ``cat``).
+
+    Returns
+    -------
+    File
+        The newly written file, opened in read mode. Close it when done (or use
+        it as a context manager). Callers that only need the file on disk may
+        ignore the return value.
+
+    Raises
+    ------
+    ValueError
+        If ``sources`` is empty, if ``destination`` is also a source, if any
+        source is empty, if the inputs disagree on grid or vertical axis, or if
+        the same valid time appears in more than one input.
+
+    Examples
+    --------
+    Join three 6-hourly HRRR files into one daily file:
+
+    >>> import arlmet
+    >>> arlmet.concat(
+    ...     ["20240101_00_hrrr", "20240101_06_hrrr", "20240101_12_hrrr"],
+    ...     "20240101_hrrr",
+    ... )
+
+    Combine every 6-hourly file for one day discovered by glob (``sort=True``
+    orders them by valid time, so glob order does not matter):
+
+    >>> import glob
+    >>> arlmet.concat(glob.glob("20240101_*_hrrr"), "20240101_hrrr")
+    """
+    # A bare str/PathLike is iterable (over characters / not at all), which would
+    # silently do the wrong thing — reject it explicitly.
+    if isinstance(sources, (str, bytes, os.PathLike)):
+        raise TypeError(
+            "sources must be an iterable of paths, not a single path. "
+            "Wrap a single file in a list: concat([path], destination)."
+        )
+
+    source_paths = [Path(p) for p in sources]
+    if not source_paths:
+        raise ValueError("concat requires at least one source file.")
+
+    destination = Path(destination)
+    destination_resolved = destination.resolve()
+    if any(p.resolve() == destination_resolved for p in source_paths):
+        raise ValueError(
+            f"destination {destination} is also one of the sources; "
+            "concatenating a file onto itself is not allowed."
+        )
+
+    ordered_paths = _scan_sources(source_paths, sort=sort)
+
+    with open(destination, "wb") as out:
+        for path in ordered_paths:
+            with open(path, "rb") as src:
+                shutil.copyfileobj(src, out)
+
+    return File(destination)
+
+
+def _scan_sources(source_paths: list[Path], *, sort: bool) -> list[Path]:
+    """
+    Read each source's index records to validate compatibility and order by time.
+
+    Returns the paths in write order. Raises if any source is empty, the grids
+    or vertical axes disagree, or a valid time is shared across sources.
+    """
+    scanned = []
+    for path in source_paths:
+        with File(path) as src:
+            times = src.times
+            if not times:
+                # An empty file never set a grid/axis, so check before reading them.
+                raise ValueError(f"Source file {path} contains no records.")
+            grid = src.grid
+            axis = src.vertical_axis
+
+        scanned.append((path, times, grid, axis))
+
+    # source_paths is non-empty (checked by concat), so scanned[0] exists.
+    reference_path, _, reference_grid, reference_axis = scanned[0]
+    for path, _times, grid, axis in scanned[1:]:
+        if grid != reference_grid:
+            raise ValueError(
+                f"Grid mismatch: {path} has grid {grid.nx}x{grid.ny}, "
+                f"incompatible with {reference_path} "
+                f"({reference_grid.nx}x{reference_grid.ny}). "
+                "Concatenated ARL files must share a single grid."
+            )
+        if axis != reference_axis:
+            raise ValueError(
+                f"Vertical axis mismatch: {path} (flag {axis.flag}, "
+                f"{len(axis.levels)} levels) is incompatible with "
+                f"{reference_path} (flag {reference_axis.flag}, "
+                f"{len(reference_axis.levels)} levels). Concatenated ARL "
+                "files must share a single vertical axis."
+            )
+
+    if sort:
+        # times is sorted by File.times, so times[0] is each file's earliest.
+        scanned.sort(key=lambda item: item[1][0])
+
+    _reject_duplicate_times([(path, times) for path, times, _, _ in scanned])
+
+    return [path for path, _, _, _ in scanned]
+
+
+def _reject_duplicate_times(scanned: list[tuple[Path, list[pd.Timestamp]]]) -> None:
+    """Raise if any valid time appears in more than one source."""
+    owner: dict[pd.Timestamp, Path] = {}
+    for path, times in scanned:
+        for time in times:
+            if time in owner:
+                raise ValueError(
+                    f"Valid time {time} appears in both {owner[time]} and "
+                    f"{path}. Concatenated ARL files must not repeat valid times: "
+                    "arlmet cannot read a file with duplicate times and HYSPLIT "
+                    "behavior on repeated times is undefined."
+                )
+            owner[time] = path
+
+
+def concat_by_time(
+    directory: str | os.PathLike[str],
+    output_directory: str | os.PathLike[str],
+    freq: str = "1D",
+    *,
+    pattern: str = "*",
+    time_range: tuple[str | pd.Timestamp, str | pd.Timestamp] | None = None,
+    template: str = "{time:%Y%m%d}_arl",
+    sort: bool = True,
+) -> list[Path]:
+    """
+    Group every ARL file in a directory by valid time and concatenate each group.
+
+    Each input is assigned to a time bin from its first valid time — read from
+    the file's index record, not parsed from its name — floored to ``freq``. All
+    files in a bin are concatenated into one output file. This is the batch form
+    of :func:`concat`: e.g. turning a directory of 6-hourly HRRR files into one
+    file per day.
+
+    Parameters
+    ----------
+    directory : path-like
+        Directory to scan for input ARL files (non-recursive).
+    output_directory : path-like
+        Directory to write the concatenated files into. Created if missing.
+        Should differ from ``directory``.
+    freq : str, default "1D"
+        Fixed-frequency pandas offset alias giving the size of each output
+        chunk: ``"1D"`` = one file per day, ``"6h"`` = one per six hours, etc.
+        Each input is binned by its first valid time floored to this frequency,
+        so ``freq`` should be at least as long as any single input file's span.
+    pattern : str, default "*"
+        Glob (relative to ``directory``) selecting input files. Scope it to ARL
+        files; every match must be a readable ARL file.
+    time_range : tuple of (start, end), optional
+        Inclusive ``(start, end)`` filter on each file's first valid time. Files
+        whose first time falls outside the range are skipped.
+    template : str, default "{time:%Y%m%d}_arl"
+        ``str.format`` template for output filenames, given the bin start time
+        as ``time`` (a ``pandas.Timestamp``), e.g. ``"{time:%Y%m%d}_hrrr"``. It
+        must encode enough resolution to keep bins distinct at ``freq``.
+    sort : bool, default True
+        Passed through to :func:`concat` for each group.
+
+    Returns
+    -------
+    list[pathlib.Path]
+        The written output paths, one per non-empty time bin, in time order.
+
+    Raises
+    ------
+    ValueError
+        If ``pattern`` matches no files, or a matched file cannot be read as
+        ARL. :func:`concat`'s grid/axis and duplicate-time checks also apply
+        within each group.
+
+    Examples
+    --------
+    Turn a directory of 6-hourly HRRR files into one file per day:
+
+    >>> import arlmet
+    >>> arlmet.concat_by_time(
+    ...     "hrrr/",
+    ...     "daily/",
+    ...     freq="1D",
+    ...     pattern="*_hrrr",
+    ...     template="{time:%Y%m%d}_hrrr",
+    ... )
+    """
+    directory = Path(directory)
+    output_directory = Path(output_directory)
+
+    candidates = sorted(p for p in directory.glob(pattern) if p.is_file())
+    if not candidates:
+        raise ValueError(f"No files matched pattern {pattern!r} in {directory}.")
+
+    time_filter: tuple[pd.Timestamp, pd.Timestamp] | None = None
+    if time_range is not None:
+        time_filter = (pd.Timestamp(time_range[0]), pd.Timestamp(time_range[1]))
+
+    groups: dict[pd.Timestamp, list[Path]] = defaultdict(list)
+    for path in candidates:
+        first_time = _peek_first_time(path)
+        if time_filter is not None and not (
+            time_filter[0] <= first_time <= time_filter[1]
+        ):
             continue
-        outfile = f"{output_dir}/{day}_hrrr"
-        cmd = ["cat"] + files
-        with open(outfile, "wb") as fout:
-            subprocess.run(cmd, stdout=fout, check=True)
-        print(f"Created {outfile}")
+        groups[first_time.floor(freq)].append(path)
+
+    output_directory.mkdir(parents=True, exist_ok=True)
+
+    outputs: list[Path] = []
+    for bin_start in sorted(groups):
+        out_path = output_directory / template.format(time=bin_start)
+        # concat returns an open File; we only need it written, so close it.
+        with concat(groups[bin_start], out_path, sort=sort):
+            pass
+        outputs.append(out_path)
+    return outputs
+
+
+def _peek_first_time(path: Path) -> pd.Timestamp:
+    """
+    Read only the first index record to get a file's earliest valid time.
+
+    Much cheaper than ``File(path).times`` on large multi-time files: it reads
+    one index record instead of seeking to every index record in the file.
+    """
+    with open(path, "rb") as handle:
+        try:
+            return IndexRecord.from_position(handle, 0).time
+        except Exception as exc:
+            raise ValueError(
+                f"Could not read an ARL index record from {path}: {exc}. "
+                "Scope `pattern` so it only matches ARL files."
+            ) from exc

--- a/src/arlmet/concat.py
+++ b/src/arlmet/concat.py
@@ -1,0 +1,41 @@
+import glob
+import os
+import subprocess
+
+# This script takes 6 hourly HRRR files and concatenates these
+# into daily chunks so avoid file limit issues within HYSPLIT,
+# which will not allow more than 12 met files to be included as
+# inputs.     DVM 6/18/2026
+
+# What is our input and output directories?
+input_dir = "./hrrr"
+output_dir = "./HRRR_tmp"
+
+# What months and year are we processing?
+year = "2024"
+months = [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12]
+
+# Make the output directory if it does not exist
+os.makedirs(output_dir, exist_ok=True)
+
+# Loop through each month
+for month in months:
+    # Find all the unique days for the period of time we are looking at
+    days = sorted(
+        {
+            os.path.basename(f).split("_")[0]
+            for f in glob.glob(f"{input_dir}/{year}{month:02d}*_hrrr")
+        }
+    )
+
+    # Loop through each day, and then find the HRRR files for the
+    # corresponding day. Then concatenate the files together
+    for day in days:
+        files = sorted(glob.glob(f"{input_dir}/{day}_*_hrrr"))
+        if len(files) == 0:
+            continue
+        outfile = f"{output_dir}/{day}_hrrr"
+        cmd = ["cat"] + files
+        with open(outfile, "wb") as fout:
+            subprocess.run(cmd, stdout=fout, check=True)
+        print(f"Created {outfile}")

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -1,0 +1,293 @@
+"""Tests for concatenating ARL files into a single file."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from arlmet import File, concat, concat_by_time
+from arlmet.grid import Grid, Projection
+from arlmet.vertical import PressureAxis
+
+
+def make_test_grid(nx: int = 20, ny: int = 20) -> Grid:
+    projection = Projection(
+        pole_lat=90.0,
+        pole_lon=0.0,
+        tangent_lat=1.0,
+        tangent_lon=1.0,
+        grid_size=0.0,
+        orientation=0.0,
+        cone_angle=0.0,
+        sync_x=1.0,
+        sync_y=1.0,
+        sync_lat=-10.0,
+        sync_lon=20.0,
+    )
+    return Grid(projection=projection, nx=nx, ny=ny)
+
+
+def write_arl(path, times, *, grid=None, vertical_axis=None, source="TEST"):
+    """Write a small ARL file with PRSS+TEMP records at each given time."""
+    grid = grid if grid is not None else make_test_grid()
+    vertical_axis = (
+        vertical_axis
+        if vertical_axis is not None
+        else PressureAxis(levels=[0.0, 1000.0])
+    )
+    base = np.arange(grid.nx * grid.ny, dtype=np.float32).reshape(grid.ny, grid.nx)
+
+    with File(
+        path, mode="w", source=source, grid=grid, vertical_axis=vertical_axis
+    ) as arl:
+        for i, time in enumerate(times):
+            time = pd.Timestamp(time)
+            rs = arl.create_recordset(time, forecast=0)
+            rs.create_datarecord("PRSS", level=0, forecast=0, data=1000.0 + base + i)
+            rs.create_datarecord("TEMP", level=1, forecast=0, data=280.0 + base + i)
+    return path
+
+
+def test_concat_joins_files_in_time_order(tmp_path):
+    early = write_arl(tmp_path / "early.arl", ["2024-01-01 00:00", "2024-01-01 06:00"])
+    late = write_arl(tmp_path / "late.arl", ["2024-01-01 12:00", "2024-01-01 18:00"])
+    out = tmp_path / "day.arl"
+
+    # Pass out of order; sort=True should chronologically order the output.
+    concat([late, early], out)
+
+    with File(out) as merged:
+        assert merged.times == [
+            pd.Timestamp("2024-01-01 00:00"),
+            pd.Timestamp("2024-01-01 06:00"),
+            pd.Timestamp("2024-01-01 12:00"),
+            pd.Timestamp("2024-01-01 18:00"),
+        ]
+        assert merged.grid == make_test_grid()
+        assert merged.vertical_axis.levels.tolist() == [0.0, 1000.0]
+
+
+def test_concat_is_byte_level_append(tmp_path):
+    a = write_arl(tmp_path / "a.arl", ["2024-01-01 00:00"])
+    b = write_arl(tmp_path / "b.arl", ["2024-01-01 06:00"])
+    out = tmp_path / "ab.arl"
+
+    concat([a, b], out, sort=False)
+
+    # With sort=False the output is exactly the inputs appended in order.
+    assert out.read_bytes() == a.read_bytes() + b.read_bytes()
+
+
+def test_concat_preserves_record_values(tmp_path):
+    a = write_arl(tmp_path / "a.arl", ["2024-01-01 00:00"])
+    b = write_arl(tmp_path / "b.arl", ["2024-01-01 06:00"])
+    out = tmp_path / "ab.arl"
+
+    concat([a, b], out)
+
+    with File(a) as fa, File(b) as fb, File(out) as merged:
+        for src in (fa, fb):
+            for time in src.times:
+                for level, var in ((0, "PRSS"), (1, "TEMP")):
+                    np.testing.assert_array_equal(
+                        merged[time][(level, var)].read(),
+                        src[time][(level, var)].read(),
+                    )
+
+
+def test_concat_returns_open_file(tmp_path):
+    a = write_arl(tmp_path / "a.arl", ["2024-01-01 00:00"])
+    b = write_arl(tmp_path / "b.arl", ["2024-01-01 06:00"])
+    out = tmp_path / "ab.arl"
+
+    result = concat([a, b], out)
+    try:
+        assert isinstance(result, File)
+        assert result.path == out
+        assert len(result.times) == 2
+    finally:
+        result.close()
+
+
+def test_concat_single_source_acts_as_copy(tmp_path):
+    a = write_arl(tmp_path / "a.arl", ["2024-01-01 00:00", "2024-01-01 06:00"])
+    out = tmp_path / "copy.arl"
+
+    concat([a], out)
+
+    assert out.read_bytes() == a.read_bytes()
+
+
+def test_concat_rejects_grid_mismatch(tmp_path):
+    a = write_arl(tmp_path / "a.arl", ["2024-01-01 00:00"], grid=make_test_grid(20, 20))
+    b = write_arl(tmp_path / "b.arl", ["2024-01-01 06:00"], grid=make_test_grid(25, 25))
+    out = tmp_path / "out.arl"
+
+    with pytest.raises(ValueError, match="Grid mismatch"):
+        concat([a, b], out)
+
+
+def test_concat_rejects_vertical_axis_mismatch(tmp_path):
+    a = write_arl(
+        tmp_path / "a.arl",
+        ["2024-01-01 00:00"],
+        vertical_axis=PressureAxis(levels=[0.0, 1000.0]),
+    )
+    b = write_arl(
+        tmp_path / "b.arl",
+        ["2024-01-01 06:00"],
+        vertical_axis=PressureAxis(levels=[0.0, 925.0]),
+    )
+    out = tmp_path / "out.arl"
+
+    with pytest.raises(ValueError, match="Vertical axis mismatch"):
+        concat([a, b], out)
+
+
+def test_concat_rejects_duplicate_times(tmp_path):
+    a = write_arl(tmp_path / "a.arl", ["2024-01-01 00:00", "2024-01-01 06:00"])
+    b = write_arl(tmp_path / "b.arl", ["2024-01-01 06:00", "2024-01-01 12:00"])
+    out = tmp_path / "out.arl"
+
+    with pytest.raises(ValueError, match="appears in both"):
+        concat([a, b], out)
+
+
+def test_concat_rejects_bare_string_source(tmp_path):
+    a = write_arl(tmp_path / "a.arl", ["2024-01-01 00:00"])
+    out = tmp_path / "out.arl"
+
+    with pytest.raises(TypeError, match="iterable of paths"):
+        concat(str(a), out)
+
+
+def test_concat_rejects_empty_sources(tmp_path):
+    with pytest.raises(ValueError, match="at least one source"):
+        concat([], tmp_path / "out.arl")
+
+
+def test_concat_rejects_destination_in_sources(tmp_path):
+    a = write_arl(tmp_path / "a.arl", ["2024-01-01 00:00"])
+
+    with pytest.raises(ValueError, match="also one of the sources"):
+        concat([a], a)
+
+
+def test_concat_rejects_empty_source_file(tmp_path):
+    a = write_arl(tmp_path / "a.arl", ["2024-01-01 00:00"])
+    empty = tmp_path / "empty.arl"
+    empty.write_bytes(b"")
+    out = tmp_path / "out.arl"
+
+    with pytest.raises(ValueError, match="contains no records"):
+        concat([a, empty], out)
+
+
+# --- concat_by_time -------------------------------------------------------
+
+
+def populate_hrrr_dir(directory):
+    """Write 6-hourly single-time ARL files spanning two days into `directory`."""
+    directory.mkdir(parents=True, exist_ok=True)
+    times = [
+        "2024-01-01 00:00",
+        "2024-01-01 06:00",
+        "2024-01-01 12:00",
+        "2024-01-01 18:00",
+        "2024-01-02 00:00",
+        "2024-01-02 06:00",
+    ]
+    for time in times:
+        stamp = pd.Timestamp(time)
+        write_arl(directory / f"{stamp:%Y%m%d_%H}_hrrr", [time])
+    return times
+
+
+def test_concat_by_time_groups_by_day(tmp_path):
+    src = tmp_path / "hrrr"
+    out = tmp_path / "daily"
+    populate_hrrr_dir(src)
+
+    written = concat_by_time(
+        src, out, freq="1D", pattern="*_hrrr", template="{time:%Y%m%d}_hrrr"
+    )
+
+    assert [p.name for p in written] == ["20240101_hrrr", "20240102_hrrr"]
+    with File(written[0]) as day1, File(written[1]) as day2:
+        assert day1.times == [
+            pd.Timestamp("2024-01-01 00:00"),
+            pd.Timestamp("2024-01-01 06:00"),
+            pd.Timestamp("2024-01-01 12:00"),
+            pd.Timestamp("2024-01-01 18:00"),
+        ]
+        assert day2.times == [
+            pd.Timestamp("2024-01-02 00:00"),
+            pd.Timestamp("2024-01-02 06:00"),
+        ]
+
+
+def test_concat_by_time_respects_freq(tmp_path):
+    src = tmp_path / "hrrr"
+    out = tmp_path / "halfday"
+    populate_hrrr_dir(src)
+
+    written = concat_by_time(
+        src, out, freq="12h", pattern="*_hrrr", template="{time:%Y%m%d_%H}_hrrr"
+    )
+
+    # Day 1 splits into 00Z (00,06) and 12Z (12,18); day 2 has just 00Z (00,06).
+    assert [p.name for p in written] == [
+        "20240101_00_hrrr",
+        "20240101_12_hrrr",
+        "20240102_00_hrrr",
+    ]
+
+
+def test_concat_by_time_time_range_filters(tmp_path):
+    src = tmp_path / "hrrr"
+    out = tmp_path / "daily"
+    populate_hrrr_dir(src)
+
+    written = concat_by_time(
+        src,
+        out,
+        freq="1D",
+        pattern="*_hrrr",
+        template="{time:%Y%m%d}_hrrr",
+        time_range=("2024-01-02 00:00", "2024-01-02 23:00"),
+    )
+
+    assert [p.name for p in written] == ["20240102_hrrr"]
+    with File(written[0]) as day2:
+        assert len(day2.times) == 2
+
+
+def test_concat_by_time_creates_output_dir(tmp_path):
+    src = tmp_path / "hrrr"
+    out = tmp_path / "nested" / "daily"
+    populate_hrrr_dir(src)
+
+    written = concat_by_time(
+        src, out, freq="1D", pattern="*_hrrr", template="{time:%Y%m%d}_hrrr"
+    )
+
+    assert out.is_dir()
+    assert all(p.exists() for p in written)
+
+
+def test_concat_by_time_raises_on_no_matches(tmp_path):
+    src = tmp_path / "hrrr"
+    populate_hrrr_dir(src)
+
+    with pytest.raises(ValueError, match="No files matched"):
+        concat_by_time(src, tmp_path / "out", pattern="*.nope")
+
+
+def test_concat_by_time_rejects_non_arl_file(tmp_path):
+    src = tmp_path / "hrrr"
+    populate_hrrr_dir(src)
+    (src / "junk_hrrr").write_bytes(b"not an arl file")
+
+    with pytest.raises(ValueError, match="Could not read an ARL index record"):
+        concat_by_time(
+            src, tmp_path / "out", pattern="*_hrrr", template="{time:%Y%m%d}_hrrr"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -207,7 +207,7 @@ wheels = [
 
 [[package]]
 name = "arlmet"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Adds two functions for joining ARL meteorology files, refactored from a script
written by Derek Mallia (committed first, verbatim, so authorship is preserved):

- `arlmet.concat(sources, destination, *, sort=True)` — join several ARL files into one.
- `arlmet.concat_by_time(directory, output_directory, freq="1D", ...)` — batch form
  that groups a directory of files into time-binned chunks (e.g. 6-hourly → daily).

## Why

HYSPLIT caps a simulation at **12 meteorological input files** when a single grid
is specified. From the [HYSPLIT user guide, "Compilation Limits"](https://www.ready.noaa.gov/hysplitusersguide/S441.htm):

> With HYSPLIT V4.5 most compilation array limits have been eliminated through the
> use of dynamic array allocation. However, one restriction remains with regard to
> the meteorological input data: if only a single value of grids is specified, the
> maximum number of meteorological data files is limited to a maximum of 12 per
> simulation.

So to drive a long simulation you must combine many short (e.g. 6-hourly) met files
into fewer, longer (e.g. daily) files. This is a recurring need; this PR makes it a
first-class, validated operation in `arlmet`.

## How it works / design decisions

**Byte-level append.** ARL files are flat streams of fixed-size records, so joining
them is literally `cat a b > out` — no repacking. `concat` copies bytes directly,
preserving every record (including DIF records and checksums) exactly.

**Validation before the cat.** A blind `cat` of incompatible files yields a corrupt
ARL (different grids → different record lengths). `concat` first scans each input's
index records and:
- requires a shared grid + vertical axis (raises otherwise);
- rejects repeated valid times (arlmet can't read a file with duplicate times, and
  HYSPLIT behavior on repeats is undefined);
- orders inputs by valid time (`sort=True`, default) so the output is chronological
  regardless of input order.

**`concat_by_time` derives each file's time bin from its index record, not its
filename.** Derek's original script parsed the date out of the filename; reading it
from the file instead is robust to any naming scheme. I benchmarked the cost on real
3.5 GB HRRR files to confirm it's negligible:

| per file | cold cache | warm |
|---|---|---|
| read first index record (the bin time) | ~1.1 ms | ~0.9 ms |
| parse filename | ~0.1 ms | ~0.0 ms |
| _(byte-copy the file — unavoidable, both paths)_ | ~5.8 s | — |

The ~1 ms/file index read is swamped by the multi-second byte copy both approaches
must pay, so we take the robust path. It reads only the *first* index record per
file, not a full `File().times` scan (which is ~440 ms/file cold on these large
files because each index record is scattered across the 3.5 GB stream).

## Attribution

The first commit is Derek Mallia's original `concat_hrrr_daily.py`, committed
verbatim and authored by him, so `git blame`/history credit him for the origin.
Later commits refactor it into the package API.

## Also included

- `chore: sync uv.lock to 0.1.0a4` — the v0.1.0a4 release bumped `pyproject.toml`
  but left `uv.lock` pinned at `0.1.0a3`, so the editable-install hook re-synced it
  on every commit. Fixed here.

## Testing

- `tests/test_concat.py` — 18 tests: byte-identity vs `cat`, time ordering,
  single-source copy, grid/axis-mismatch + duplicate-time + empty-file rejection;
  `concat_by_time` daily and sub-daily (`12h`) grouping, `time_range` filter,
  output-dir creation, and the no-match / non-ARL error paths.
- Full suite green: **327 passed**.
